### PR TITLE
Fixes macro bug where DEBUG_SERIAL wasn't assigned in certain cases

### DIFF
--- a/fc/src/settings.h
+++ b/fc/src/settings.h
@@ -20,7 +20,7 @@
 #if DEBUG_SERIAL_ENABLE
     #define DEBUG_SERIAL(x) Serial.println(x)
 #else
-    #define DEBUG_SERIAL(x)
+    #define DEBUG_SERIAL(x) x
 #endif
 
 #endif

--- a/lib/Telemetry/src/JsonMaker.cpp
+++ b/lib/Telemetry/src/JsonMaker.cpp
@@ -6,7 +6,7 @@ JsonMaker::JsonMaker() {
 }
 
 void JsonMaker::_init() {
-    memset(_buf, 0, sizeof(_buf));
+    memset(_buf, 0, sizeof(_buf)); // _buf = 1024 character buffer (passed as pointer in this case)
     this->_writer = new JSONBufferWriter(_buf, sizeof(_buf) - 1);
 
     _writer->beginObject();
@@ -45,5 +45,3 @@ void JsonMaker::refresh() {
     if(this->_writer != NULL) delete this->_writer;
     _init();
 }
-
-

--- a/proto/src/main.cpp
+++ b/proto/src/main.cpp
@@ -139,8 +139,6 @@ void loop() {
         lastPublish = millis();
         publishMessage();
     }
-
-    
 }
 
 

--- a/proto/src/settings.h
+++ b/proto/src/settings.h
@@ -20,7 +20,7 @@
 #if DEBUG_SERIAL_ENABLE
     #define DEBUG_SERIAL(x) Serial.println(x)
 #else
-    #define DEBUG_SERIAL(x)
+    #define DEBUG_SERIAL(x) x
 #endif
 
 #endif

--- a/urban/src/settings.h
+++ b/urban/src/settings.h
@@ -20,7 +20,7 @@
 #if DEBUG_SERIAL_ENABLE
     #define DEBUG_SERIAL(x) Serial.println(x)
 #else
-    #define DEBUG_SERIAL(x)
+    #define DEBUG_SERIAL(x) x
 #endif
 
 #endif


### PR DESCRIPTION
Adds DEBUG_SERIAL(x) x so x is called when DEBUG_SERIAL_ENABLE is false