### PR TITLE
Update workflow so it's less verbose.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,25 +11,19 @@ jobs:
           submodules: recursive
           fetch-depth: 5
 
-      - name: Diff Source
-        uses: marceloprado/has-changed-path@v1
+      - name: Diff Source and Libraries
+        uses: MarceloPrado/has-changed-path@v1.0
         id: changed
         with:
-          paths: urban
-      
-      - name: Diff Libraries
-        uses: marceloprado/has-changed-path@v1
-        id: lib-changed
-        with:
-          paths: lib
+          paths: urban lib
 
       - name: Build
-        if: steps.changed.outputs.changed == 'true' || steps.lib-changed.outputs.changed == 'true'
+        if: steps.changed.outputs.changed == 'true'
         run: |
           make urban
 
       - name: Upload
-        if: steps.changed.outputs.changed == 'true' || steps.lib-changed.outputs.changed == 'true'
+        if: steps.changed.outputs.changed == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: urban-${{ github.sha }}
@@ -44,25 +38,19 @@ jobs:
           submodules: recursive
           fetch-depth: 5
 
-      - name: Diff Source
-        uses: marceloprado/has-changed-path@v1
+      - name: Diff Source and Libraries
+        uses: MarceloPrado/has-changed-path@v1.0
         id: changed
         with:
-          paths: proto
-      
-      - name: Diff Libraries
-        uses: marceloprado/has-changed-path@v1
-        id: lib-changed
-        with:
-          paths: lib
+          paths: proto lib
 
       - name: Build
-        if: steps.changed.outputs.changed == 'true' || steps.lib-changed.outputs.changed == 'true'
+        if: steps.changed.outputs.changed == 'true'
         run: |
           make proto
 
       - name: Upload
-        if: steps.changed.outputs.changed == 'true' || steps.lib-changed.outputs.changed == 'true'
+        if: steps.changed.outputs.changed == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: proto-${{ github.sha }}
@@ -77,25 +65,19 @@ jobs:
           submodules: recursive
           fetch-depth: 5
 
-      - name: Diff Source
-        uses: marceloprado/has-changed-path@v1
+      - name: Diff Source and Libraries
+        uses: MarceloPrado/has-changed-path@v1.0
         id: changed
         with:
-          paths: fc
-      
-      - name: Diff Libraries
-        uses: marceloprado/has-changed-path@v1
-        id: lib-changed
-        with:
-          paths: lib
+          paths: fc lib
 
       - name: Build
-        if: steps.changed.outputs.changed == 'true' || steps.lib-changed.outputs.changed == 'true'
+        if: steps.changed.outputs.changed == 'true'
         run: |
           make fc
 
       - name: Upload
-        if: steps.changed.outputs.changed == 'true' || steps.lib-changed.outputs.changed == 'true'
+        if: steps.changed.outputs.changed == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: fc-${{ github.sha }}


### PR DESCRIPTION
No functional change here, but rather just a shorter workflow since the diff of the lib and vehicle-specific code can be combined into one step. It still otherwise functions exactly as before.

The caveat as pointed out in #19 is that the file changes that it'll check for is between the current commit and the parent. This means that if you push multiple commits, there's a chance your changes won't build. This won't be an issue for PRs though since it should do a check on the entire branch.