### PR TITLE
Develop ecu checksum fixes

### DIFF
--- a/src/Sensor/SensorEcu.h
+++ b/src/Sensor/SensorEcu.h
@@ -2,7 +2,6 @@
 #define _SENSOR_ECU_H_
 
 #include "Sensor.h"
-#include "settings.h"
 
 class SensorEcu : public Sensor {
     public:

--- a/src/settings.h
+++ b/src/settings.h
@@ -7,7 +7,7 @@
 // If no argument is passed to compiler, allow us to manually define a vehicle
 #if !defined(PROTO) && !defined(URBAN) && !defined(FC)
     // SELECT VEHICLE: PROTO URBAN FC 
-    #define URBAN
+    #define PROTO
 #endif
 
 // Logging enabled at boot-up, control logging with button or Particle Function


### PR DESCRIPTION
Troubleshooted a bug that Valentino and I experienced yesterday where checksum of incoming ECU data would often be wrong. Discovered that it's only wrong when header is incorrect, which is OK, moved checksum check after header check and cleaned up some other parts of SensorEcu (largely sloppy coding on my part from last year). 