### PR TITLE
Develop gps greenlist and greenlist override

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,7 +76,11 @@
         "filesystem": "cpp",
         "xmemory": "cpp",
         "xtr1common": "cpp",
-        "xutility": "cpp"
+        "xutility": "cpp",
+        "list": "cpp",
+        "strstream": "cpp",
+        "typeindex": "cpp",
+        "variant": "cpp"
     },
     "C_Cpp.default.configurationProvider": "particle.particle-vscode-core"
 }

--- a/src/Sensor/SensorGps.cpp
+++ b/src/Sensor/SensorGps.cpp
@@ -1,5 +1,6 @@
 #include "SensorGps.h"
 #include "settings.h"
+#include "gpsGreenlist.h"
 
 // GPS Update Frequency in Hz (1-10)
 #define UPDATE_FREQ 4
@@ -76,11 +77,33 @@ uint32_t SensorGps::getUnixTime() {
 }
 
 String SensorGps::getLongitude() {
-    return FLOAT_TO_STRING(_gps->getLongitude() / TEN_POWER_SEVEN, 6);
+    double longitude = _gps->getLongitude() / TEN_POWER_SEVEN;
+    double latitude = _gps->getLatitude() / TEN_POWER_SEVEN;
+    if(_override) {
+        return FLOAT_TO_STRING(longitude, 6);
+    } else {
+        for(positionBox p : GREEN_LIST) {
+            if(p.isWithin(longitude, latitude)) {
+                return FLOAT_TO_STRING(longitude, 6);
+            }
+        }
+    }
+    return "?";
 }
 
 String SensorGps::getLatitude() {
-    return FLOAT_TO_STRING(_gps->getLatitude() / TEN_POWER_SEVEN, 6);
+    double longitude = _gps->getLongitude() / TEN_POWER_SEVEN;
+    double latitude = _gps->getLatitude() / TEN_POWER_SEVEN;
+    if(_override) {
+        return FLOAT_TO_STRING(latitude, 6);
+    } else {
+        for(positionBox p : GREEN_LIST) {
+            if(p.isWithin(longitude, latitude)) {
+                return FLOAT_TO_STRING(latitude, 6);
+            }
+        }
+    }
+    return "?";
 }
 
 String SensorGps::getHeading() {
@@ -127,3 +150,9 @@ int SensorGps::getSatellitesInView() {
 void SensorGps::updateSpeedCallback(void (*speed)(float)){
    _speedCallback  = speed;
 }
+
+void SensorGps::toggleOverride() {
+    _override = !_override;
+}
+
+

--- a/src/Sensor/SensorGps.h
+++ b/src/Sensor/SensorGps.h
@@ -92,9 +92,16 @@ class SensorGps : public Sensor {
         int getSatellitesInView();
 
         /**
-         * @return Horizontal speed (m/s) fro ethe steering wheel
+         * @brief Update the callback function used by GPS to notify higher-level class of new GPS speed
+         * 
+         * @param speed() Pointer to function to call when there is a new speed
          **/
         void updateSpeedCallback(void (*speed)(float));
+
+        /**
+         * @brief Toggle greenlist override
+         **/
+        void toggleOverride();
 
     private:
         SFE_UBLOX_GNSS* _gps;
@@ -110,6 +117,7 @@ class SensorGps : public Sensor {
         float _lastVerticalSpeed = 0.0;
         float _verticalAcceleration = 0.0;
         void (*_speedCallback)(float) = NULL;
+        bool _override = false;
 
 };
 

--- a/src/System/Button.cpp
+++ b/src/System/Button.cpp
@@ -1,12 +1,14 @@
 #include "Button.h"
 
 #define DEBOUNCE_TIME 50
+#define HOLD_TIME 2000
 
-Button::Button(uint16_t pin, bool activeHigh, bool normallyOpen, void (*callbackPushed)() = NULL, void (*callbackReleased)() = NULL){
+Button::Button(uint16_t pin, bool activeHigh, bool normallyOpen, void (*callbackPushed)(), void (*callbackReleased)(), void (*callbackHolding)()){
     _pin = pin;
     _activeHigh = activeHigh;
     _callbackPushed = callbackPushed;
     _callbackReleased = callbackReleased;
+    _callbackHolding = callbackHolding;
 
     // Enable input pin with a built-in resistor pulling opposite of active
     if(_activeHigh){
@@ -26,17 +28,34 @@ Button::~Button(){}
 void Button::begin(){}
 
 void Button::handle(){
+
     bool newState = pinReadFast(_pin);
     if(!_activeHigh){
         newState = !newState;
     }
+
     if(newState != _state && millis() > _lastChange + DEBOUNCE_TIME){
         _state = newState;
         _lastChange = millis();
+        _holding = true;
         if(newState){
             if(_callbackPushed != NULL) _callbackPushed();
         }else{
             if(_callbackReleased != NULL) _callbackReleased();
+        }
+    }
+
+    if(_holding) {
+        if(millis() < _lastChange + HOLD_TIME) {
+            if(!newState) {
+                _holding = false;
+            }
+        } else {
+            if(newState) {
+                _callbackPushed();
+                _callbackHolding();
+            }
+            _holding = false;
         }
     }
 }

--- a/src/System/Button.h
+++ b/src/System/Button.h
@@ -14,9 +14,15 @@ class Button : public Handleable {
          * @param normallyOpen is true if the button is normall open
          * @param callbackPushed void function to call when the button is pushed down
          * @param callbackReleased void function to call when the button is released
+         * @param callbackHeld void function to call when the button is held for 2s
          * 
          * */
-        Button(uint16_t pin, bool activeHigh, bool normallyOpen, void (*callbackPushed)(), void (*callbackReleased)());
+        Button( uint16_t pin, 
+                bool activeHigh, 
+                bool normallyOpen, 
+                void (*callbackPushed)() = NULL, 
+                void (*callbackReleased)() = NULL, 
+                void (*callbackHolding)() = NULL);
         ~Button();
 
         void begin();
@@ -37,9 +43,11 @@ class Button : public Handleable {
         bool _activeHigh;
 
         bool _state = false;
+        bool _holding = false;
         uint32_t _lastChange = 0;
         void (*_callbackPushed)();
         void (*_callbackReleased)();
+        void (*_callbackHolding)();
 };
 
 #endif

--- a/src/gpsGreenlist.h
+++ b/src/gpsGreenlist.h
@@ -1,0 +1,27 @@
+#ifndef _GPS_GREENLIST_H_
+#define _GPS_GREENLIST_H_
+
+#include <utility>
+
+// This files defines GPS co-ordinate "boxes" where GPS position will be uploaded
+// If the position is outside of one of these boxes, GPS position not uploaded for security
+// IMPORTANT: Update this greenlist with any new areas used for testing/competitions
+
+struct positionBox {
+    double northLat;
+    double southLat;
+    double westLon;
+    double eastLon;
+
+    bool isWithin(double lon, double lat) {
+        return lat <= northLat && lat >= southLat && lon >= westLon && lon <= eastLon;
+    }
+};
+
+const positionBox GREEN_LIST[] = {  {/*N*/49.286, /*S*/49.239, /*W*/-123.281, /*E*/-123.222},   // UBC
+                                    {/*N*/49.132, /*S*/49.120, /*W*/-122.339, /*E*/-122.307}};  // Mission Race Ways
+                                    
+// positionBox UBC(/*N*/49.286, /*S*/49.239, /*W*/-123.281, /*E*/-123.222);
+// positionBox MissionRaceway(/*N*/49.132, /*S*/49.120, /*W*/-122.339, /*E*/-122.307);
+
+#endif

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -16,6 +16,7 @@
 extern DataQueue dataQ;
 
 namespace CurrentVehicle {
+
     /**
      *  Returns dispatcher with current vehicle's set of commands
     **/
@@ -36,6 +37,10 @@ namespace CurrentVehicle {
     **/
     uint32_t getUnixTime(); 
 
+    /**
+     * @brief Toggle override for GPS position greenlist
+    **/
+    void toggleGpsOverride();
 }
 
 #endif

--- a/src/vehicleFc.cpp
+++ b/src/vehicleFc.cpp
@@ -57,5 +57,9 @@ bool CurrentVehicle::getTimeValid() {
 uint32_t CurrentVehicle::getUnixTime() {
     return gps.getUnixTime();
 }
+
+void CurrentVehicle::toggleGpsOverride() {
+    gps.toggleOverride();
+}
  
 #endif

--- a/src/vehicleProto.cpp
+++ b/src/vehicleProto.cpp
@@ -74,4 +74,8 @@ uint32_t CurrentVehicle::getUnixTime() {
     return gps.getUnixTime();
 }
 
+void CurrentVehicle::toggleGpsOverride() {
+    gps.toggleOverride();
+}
+
 #endif

--- a/src/vehicleUrban.cpp
+++ b/src/vehicleUrban.cpp
@@ -111,4 +111,8 @@ uint32_t CurrentVehicle::getUnixTime() {
     return gps.getUnixTime();
 }
 
+void CurrentVehicle::toggleGpsOverride() {
+    gps.toggleOverride();
+}
+
 #endif


### PR DESCRIPTION
This adds a new file, src/gpsGreenlist.h, where we can define boxes where the GPS should upload position (lat/long). Altitude and all other GPS sensor properties are unaffected. I've added the entire UBC campus and Mission Race Ways to this header file so far. We will have to add more venues as we do parking lot tests, track tests, and competitions. 

Also adds an override, where you can hold the button for 2 seconds and the greenlist will be ignored. The error light will flash in override mode, and the serial monitor will print repeated warnings. Closes #84 