### PR TITLE
added Thermo debug mode and changed name of CAN debug mode

### DIFF
--- a/src/Sensor/SensorThermo.cpp
+++ b/src/Sensor/SensorThermo.cpp
@@ -1,4 +1,9 @@
 #include "SensorThermo.h"
+#include "settings.h"
+
+// #define DEBUG_THERMO
+
+#define DEBUG_THERMO_INTERVAL 250
 
 SensorThermo::SensorThermo(SPIClass *spi, uint8_t csPin){
     _spi = spi;
@@ -16,6 +21,31 @@ void SensorThermo::begin() {
 }
 
 void SensorThermo::handle() {
+    #ifdef DEBUG_THERMO
+        if(millis() > _lastDebug + DEBUG_THERMO_INTERVAL) {
+            _lastDebug = millis();
+
+            Serial.print(getHumanName());
+
+            uint8_t error = _probe->readError();
+            switch(error) {
+                case 1: 
+                    Serial.println(" ERROR: No Thermocouple Detected");
+                    break;
+                case 2:
+                    Serial.println(" ERROR: Thermocouple Shorted To GND");
+                    break;
+                case 4:
+                    Serial.println(" ERROR: Thermocouple Shorted To VCC");
+                    break;
+                default:
+                    Serial.println(" " + FLOAT_TO_STRING(_probe->readCelsius(),2) + "°C");
+                    break;
+            }
+        
+        }
+
+    #endif
 }
 
 int SensorThermo::getProbeTemp() {

--- a/src/Sensor/SensorThermo.h
+++ b/src/Sensor/SensorThermo.h
@@ -41,6 +41,7 @@ class SensorThermo : public Sensor {
         Adafruit_MAX31855* _probe;
         SPIClass *_spi;
         uint8_t _csPin;
+        uint32_t _lastDebug = 0;
 };
 
 #endif

--- a/src/System/CanInterface.cpp
+++ b/src/System/CanInterface.cpp
@@ -1,7 +1,7 @@
 #include "CanInterface.h"
 #define CAN_FRAME 0
 
-// #define DEBUG_MODE
+// #define DEBUG_CAN
 
 CanInterface::CanInterface(SPIClass *spi, uint8_t csPin, uint8_t intPin) {
     pinMode(intPin, INPUT);
@@ -27,7 +27,7 @@ void CanInterface::handle() {
             _CAN->readMsgBuf(&message.dataLength, message.data);
             message.id = _CAN->getCanId();
 
-            #ifdef DEBUG_MODE 
+            #ifdef DEBUG_CAN 
                 DEBUG_SERIAL_LN("-----------------------------");
                 DEBUG_SERIAL_F("CAN MESSAGE RECEIVED - ID: 0x%X\n", message.id);
 


### PR DESCRIPTION
Added  a thermo debug mode to display thermocouple status repeatedly, for debugging thermocouple wires (I happen to be building a few more right now). Changes name of CAN debug mode for consistency. 