### PR TITLE
Develop fc sensor

### DIFF
--- a/src/Sensor/SensorEcu.cpp
+++ b/src/Sensor/SensorEcu.cpp
@@ -1,6 +1,8 @@
 #include "SensorEcu.h"
 #include "settings.h"
 
+#define ECU_BAUD                115200
+
 #define ECU_PACKET_SIZE         27
 
 #define ECU_HEADER_1            0x80
@@ -18,7 +20,7 @@ String SensorEcu::getHumanName() {
 }
 
 void SensorEcu::begin() {
-    _serial->begin(115200, SERIAL_8N1);
+    _serial->begin(ECU_BAUD, SERIAL_8N1);
 }
 
 void SensorEcu::flush() {

--- a/src/Sensor/SensorFc.cpp
+++ b/src/Sensor/SensorFc.cpp
@@ -1,0 +1,40 @@
+#include "SensorFc.h"
+#include "settings.h"
+
+#define FC_BAUD         9600
+#define FC_STOP_CHAR    '*'
+#define PUBLISH_INTERVAL 5000
+
+SensorFc::SensorFc(USARTSerial *serial) {
+    _serial = serial;
+}
+
+String SensorFc::getHumanName() {
+    return "FC Controller";
+}
+
+void SensorFc::begin() {
+    _serial->begin(FC_BAUD);
+}
+
+void SensorFc::handle() {
+
+    while(_serial->available()) {
+        char nextChar = _serial->read();
+        if(nextChar == FC_STOP_CHAR) {
+            if(millis() >= _lastUpdate + PUBLISH_INTERVAL) {
+                Particle.publish("fcdata", _buffer, PRIVATE, WITH_ACK);
+                _lastUpdate = millis();
+            }
+            
+            memset(_buffer, 0, FC_BUFFER_SIZE);
+        } else {
+            uint16_t position = 0;
+            while(_buffer[position]) {
+                position++;
+            }
+            _buffer[position] = nextChar;
+        }
+    }
+
+}

--- a/src/Sensor/SensorFc.h
+++ b/src/Sensor/SensorFc.h
@@ -1,0 +1,35 @@
+#ifndef _SENSOR_FC_H_
+#define _SENSOR_FC_H_
+
+#include "Sensor.h"
+
+#define FC_BUFFER_SIZE 512
+
+class SensorFc : public Sensor {
+    public:
+        /**
+         * Constructor 
+         * @param *serial bus receiving Fuel Cell Controller data
+         **/
+        SensorFc(USARTSerial *serial);
+
+        /**
+         * 
+         * */
+        void begin() override;
+        
+        /**
+         * 
+         * */
+        void handle() override;
+
+        String getHumanName() override;
+
+
+    private:
+        USARTSerial * _serial;
+        char _buffer[FC_BUFFER_SIZE];
+        uint32_t _lastUpdate = 0;
+};
+
+#endif

--- a/src/Sensor/SensorFc.h
+++ b/src/Sensor/SensorFc.h
@@ -5,6 +5,9 @@
 
 #define FC_BUFFER_SIZE 512
 
+// Fuel Cell Controller sensor - Temporary, can't be used in competition.
+// The nice thing about this sensor is that unless we hook up the specific
+// hardware for it, this sensor class essentially does nothing and can be left in. 
 class SensorFc : public Sensor {
     public:
         /**
@@ -14,12 +17,12 @@ class SensorFc : public Sensor {
         SensorFc(USARTSerial *serial);
 
         /**
-         * 
+         * Init serial port
          * */
         void begin() override;
         
         /**
-         * 
+         * Check serial buffer for new updates
          * */
         void handle() override;
 
@@ -30,6 +33,16 @@ class SensorFc : public Sensor {
         USARTSerial * _serial;
         char _buffer[FC_BUFFER_SIZE];
         uint32_t _lastUpdate = 0;
+
+        /**
+         * Print to serial and publish message to Particle Cloud with buffer contents
+         * */
+        void _publish();
+
+        /**
+         * Empty the buffer
+         * */
+        void _emptyBuffer();
 };
 
 #endif

--- a/src/settings.h
+++ b/src/settings.h
@@ -9,7 +9,7 @@
 // If no argument is passed to compiler, allow us to manually define a vehicle
 #if !defined(PROTO) && !defined(URBAN) && !defined(FC)
     // SELECT VEHICLE: PROTO URBAN FC 
-    #define URBAN
+    #define FC
 #endif
 
 // Logging enabled at boot-up, control logging with button or Particle Function

--- a/src/vehicleFc.cpp
+++ b/src/vehicleFc.cpp
@@ -1,4 +1,5 @@
 #include "vehicle.h"
+#include "SensorFc.h"
 #include <vector>
 
 #ifdef FC
@@ -9,6 +10,7 @@ SensorThermo thermo1(&SPI, A5);
 SensorThermo thermo2(&SPI, A4);
 SensorSigStrength sigStrength;
 SensorVoltage inVoltage;
+SensorFc fc(&Serial1);
 
 LoggingCommand<SensorSigStrength, int> signalStrength(&sigStrength, "sigstr", &SensorSigStrength::getStrength, 10);
 LoggingCommand<SensorSigStrength, int> signalQuality(&sigStrength, "sigql", &SensorSigStrength::getQuality, 10);


### PR DESCRIPTION
Temporary fuel cell controller communication. Strings received over serial are stored in a buffer, and published once we see a special '*' stop character. Published to special topic called "fcdata", so data is only viewable on Particle Console or over Serial Monitor. There are some electrical isolation issues stopping us from doing this in competition, hence the temporary nature of this sensor. 

This sensor won't take up many resources if the hardware is not connected, hence the request to merge it in to our develop branch. 