### PR TITLE
Fix Small Bugs

### DIFF
--- a/src/Sensor/CanSensorBms.h
+++ b/src/Sensor/CanSensorBms.h
@@ -115,13 +115,13 @@ class CanSensorBms : public CanListener {
 
 		// Data
 		float _batteryVoltage = 0.0f;
-        float _batteryCurrent = 0.0f;
-        float _cellVoltageMax = 0.0f;
-        float _cellVoltageMin = 0.0f;
-        float _soc = 0.0f;
-        int _tempBms = 0;
-        int _fault = NONE;
-        BmsStatus _bmsStatus = Unknown;
+                float _batteryCurrent = 0.0f;
+                float _cellVoltageMax = 0.0f;
+                float _cellVoltageMin = 0.0f;
+                float _soc = 0.0f;
+                int _tempBms = 0;
+                int _fault = NONE;
+                BmsStatus _bmsStatus = Unknown;
 
 		// Mangagement
 		uint64_t _lastUpdateTime = 0;

--- a/src/Sensor/CanSensorBms.h
+++ b/src/Sensor/CanSensorBms.h
@@ -115,13 +115,13 @@ class CanSensorBms : public CanListener {
 
 		// Data
 		float _batteryVoltage = 0.0f;
-                float _batteryCurrent = 0.0f;
-                float _cellVoltageMax = 0.0f;
-                float _cellVoltageMin = 0.0f;
-                float _soc = 0.0f;
-                int _tempBms = 0;
-                int _fault = NONE;
-                BmsStatus _bmsStatus = Unknown;
+        float _batteryCurrent = 0.0f;
+        float _cellVoltageMax = 0.0f;
+        float _cellVoltageMin = 0.0f;
+        float _soc = 0.0f;
+        int _tempBms = 0;
+        int _fault = NONE;
+        BmsStatus _bmsStatus = Unknown;
 
 		// Mangagement
 		uint64_t _lastUpdateTime = 0;

--- a/src/Sensor/CanSensorOrionBms.cpp
+++ b/src/Sensor/CanSensorOrionBms.cpp
@@ -121,10 +121,10 @@ void CanSensorOrionBms::update(CanMessage message) {
 			_validationMap[CAN_ORIONBMS_CELL] = _lastUpdateTime;
 			break;
 		case CAN_ORIONBMS_TEMP:
-			_batteryTempMin = (int)message.data[0];
-			_batteryTempMax = (int)message.data[1];
-			_batteryTempAvg = (int)message.data[2];
-			_tempBms = (int)message.data[3];
+			_batteryTempMin = (int8_t)message.data[0];
+			_batteryTempMax = (int8_t)message.data[1];
+			_batteryTempAvg = (int8_t)message.data[2];
+			_tempBms = (int8_t)message.data[3];
 			_validationMap[CAN_ORIONBMS_TEMP] = _lastUpdateTime;
 			break;
 		default:

--- a/src/vehicleUrban.cpp
+++ b/src/vehicleUrban.cpp
@@ -70,10 +70,10 @@ LoggingCommand<CanSensorBms, int> bmsFault(bms, "bmsf", &CanSensorBms::getFault,
 LoggingCommand<CanSensorBms, String> bmsSoc(bms, "soc", &CanSensorBms::getSoc, 10);
 LoggingCommand<BmsManager, int> bmsType(&bmsManager, "bmst", &BmsManager::getCurrentBms, 10);
 
-LoggingCommand<CanSensorAccessories, int> urbanHeadlights(&canSensorAccessories, "lhd", &CanSensorAccessories::getStatusHeadlights, 5);
+LoggingCommand<CanSensorAccessories, int> urbanHeadlights(&canSensorAccessories, "lhd", &CanSensorAccessories::getStatusHeadlights, 1);
 LoggingCommand<CanSensorAccessories, int> urbanBrakelights(&canSensorAccessories, "lbk", &CanSensorAccessories::getStatusBrakelights, 1);
 LoggingCommand<CanSensorAccessories, int> urbanHorn(&canSensorAccessories, "horn", &CanSensorAccessories::getStatusHorn, 1);
-LoggingCommand<CanSensorAccessories, int> urbanHazards(&canSensorAccessories, "lhd", &CanSensorAccessories::getStatusHazards, 1);
+LoggingCommand<CanSensorAccessories, int> urbanHazards(&canSensorAccessories, "lhz", &CanSensorAccessories::getStatusHazards, 1);
 LoggingCommand<CanSensorAccessories, int> urbanRightSig(&canSensorAccessories, "ltr", &CanSensorAccessories::getStatusRightSignal, 1);
 LoggingCommand<CanSensorAccessories, int> urbanLeftSig(&canSensorAccessories, "ltl", &CanSensorAccessories::getStatusLeftSignal, 1);
 LoggingCommand<CanSensorAccessories, int> urbanWipers(&canSensorAccessories, "wipe", &CanSensorAccessories::getStatusWipers, 5);


### PR DESCRIPTION
Fixes 2 bugs:

in CanSensorOrionBms
• issue with casting uint8_t to int when uint8_t represents a negative signed value 

in vehicleUrban
• duplicate names for accessories headslights and hazards