### PR TITLE
Fixes Urban Fault Behavior

### DIFF
--- a/src/Sensor/CanSensorAccessories.cpp
+++ b/src/Sensor/CanSensorAccessories.cpp
@@ -19,8 +19,11 @@ const uint8_t STATUS_IDS[] {
 };
 
 CanSensorAccessories::CanSensorAccessories(CanInterface &canInterface, uint16_t id)
-	: CanListener(canInterface, id) {
-	
+	: CanListener(canInterface, id) { }
+
+void CanSensorAccessories::begin() {
+	CanListener::begin();
+
 	for (uint8_t id : STATUS_IDS)
 		_statuses[id] = CanSensorAccessories::StatusProperty { 0, Unknown };
 }

--- a/src/Sensor/CanSensorAccessories.h
+++ b/src/Sensor/CanSensorAccessories.h
@@ -38,6 +38,11 @@ class CanSensorAccessories : public CanListener {
 		void handle() override { }
 
 		/**
+		 * @brief Calls CanListener::begin and initializes status map
+		 */
+		void begin() override;
+
+		/**
 		 * @brief Get the string name of this object
 		 */
 		String getHumanName();

--- a/src/Sensor/CanSensorOrionBms.cpp
+++ b/src/Sensor/CanSensorOrionBms.cpp
@@ -7,11 +7,7 @@ const uint16_t VALIDATION_IDS[] {
 	CAN_ORIONBMS_TEMP,
 };
 
-CanSensorOrionBms::CanSensorOrionBms(CanInterface& canInterface) : CanSensorBms(canInterface) {
-	for (uint16_t id : VALIDATION_IDS) {
-		_validationMap[id] = 0;
-	}
-}
+CanSensorOrionBms::CanSensorOrionBms(CanInterface& canInterface) : CanSensorBms(canInterface) { }
 
 CanSensorOrionBms::~CanSensorOrionBms() { }
 
@@ -21,6 +17,10 @@ void CanSensorOrionBms::begin() {
 	_canInterface.addMessageListen(CAN_ORIONBMS_PACK, orionDelegate);
 	_canInterface.addMessageListen(CAN_ORIONBMS_CELL, orionDelegate);
 	_canInterface.addMessageListen(CAN_ORIONBMS_TEMP, orionDelegate);
+
+	for (uint16_t id : VALIDATION_IDS) {
+		_validationMap[id] = 0;
+	}
 }
 
 String CanSensorOrionBms::getHumanName() {

--- a/src/Sensor/CanSensorTinyBms.cpp
+++ b/src/Sensor/CanSensorTinyBms.cpp
@@ -68,11 +68,7 @@ const uint8_t VALIDATION_IDS[] {
 };
 
 CanSensorTinyBms::CanSensorTinyBms(CanInterface &canInterface, uint16_t requestIntervalMs) 
-    : CanSensorBms(canInterface, CAN_TINYBMS_RESPONSE), _requestIntervalMs(requestIntervalMs) {
-		for (uint16_t id : VALIDATION_IDS)  {
-        	_validationMap[id] = 0;
-    	}
-    }
+    : CanSensorBms(canInterface, CAN_TINYBMS_RESPONSE), _requestIntervalMs(requestIntervalMs) { }
 
 void CanSensorTinyBms::handle() {
     if(millis() - _lastValidTime >= _requestIntervalMs) {
@@ -100,6 +96,14 @@ void CanSensorTinyBms::handle() {
     }
 
 	CanSensorBms::handle();
+}
+
+void CanSensorTinyBms::begin() {
+	CanListener::begin();
+
+	for (uint16_t id : VALIDATION_IDS)  {
+		_validationMap[id] = 0;
+	}
 }
 
 String CanSensorTinyBms::getHumanName() {

--- a/src/Sensor/CanSensorTinyBms.h
+++ b/src/Sensor/CanSensorTinyBms.h
@@ -18,6 +18,21 @@ class CanSensorTinyBms : public CanSensorBms {
         CanSensorTinyBms(CanInterface &canInterface, uint16_t requestIntervalMs);
 
 		/**
+         * @brief Repeatedly requests and stores bms data on interval
+         */
+        void handle() override;
+
+		/**
+		 * @brief Calls CanListener::begin and initializes validation map
+		 */
+		void begin() override;
+
+		/**
+         * @brief Get the string name of this object
+         */
+        String getHumanName() override;
+
+		/**
          * @brief Get the battery voltage
          */
         String getBatteryVolt(bool& valid = Sensor::dummy) override;
@@ -76,16 +91,6 @@ class CanSensorTinyBms : public CanSensorBms {
          * @brief Get current Bms status as string
          */
         String getStatusBmsString(bool& valid = Sensor::dummy) override;
-
-        /**
-         * @brief Repeatedly requests and stores bms data on interval
-         */
-        void handle() override;
-        
-        /**
-         * @brief Get the string name of this object
-         */
-        String getHumanName() override;
 
         /**
          * @brief Get the universal BMS fault code (if any)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "Handler.h"
 #include "Handleable.h"
 
-SYSTEM_MODE(AUTOMATIC);
+SYSTEM_MODE(SEMI_AUTOMATIC);
 SYSTEM_THREAD(ENABLED);
 
 // Forward declarations for callback functions
@@ -238,8 +238,7 @@ void setup() {
     // Begin all handleables
     Handler::instance().begin();
 
-    DEBUG_SERIAL_LN("---- TELEMETRY ONLINE - " + String(VEHICLE_NAME) + " ----\n");
-
+	Particle.connect();
 }
 
 /**


### PR DESCRIPTION
Apparently this fault was caused by a bad interaction between particle's connection process and our program's startup.  At first it seemed like it was being caused by the bms classes because they were simply doing more stuff during initialization--apparently inserting elements into an std::map consumes quite a lot of resources.

I've changed system mode to semi automatic and made it so Particle.connect is only called after we've instantiated and initialized all of our global objects, and this seems to have completely fixed the problem.  I've also moved all the bms class init stuff out of the constructor and into the Handleable::begin method, which is probably where it should have gone in the first place.

Fun fact:  you can call parent methods from derived classes with
`ParentClass::myMethod()`

Thanks Silviu for your help debugging this one!

