### PR TITLE
changes temp sensor properties

### DIFF
--- a/src/settings.h
+++ b/src/settings.h
@@ -9,7 +9,7 @@
 // If no argument is passed to compiler, allow us to manually define a vehicle
 #if !defined(PROTO) && !defined(URBAN) && !defined(FC)
     // SELECT VEHICLE: PROTO URBAN FC 
-    #define URBAN
+    #define PROTO
 #endif
 
 // Logging enabled at boot-up, control logging with button or Particle Function

--- a/src/vehicleProto.cpp
+++ b/src/vehicleProto.cpp
@@ -7,7 +7,7 @@
 // sensor definitions
 SensorGps gps(new SFE_UBLOX_GNSS());
 SensorThermo thermo1(&SPI, A5);
-// SensorThermo thermo2(&SPI, A4); // Currently unused
+SensorThermo thermo2(&SPI, A4);
 SensorEcu ecu(&Serial1);
 SensorSigStrength sigStrength;
 SensorVoltage inVoltage;
@@ -29,13 +29,14 @@ LoggingCommand<SensorGps, String> gpsIncline(&gps, "incl", &SensorGps::getInclin
 LoggingCommand<SensorGps, String> gpsHorAccuracy(&gps, "haccu", &SensorGps::getHorizontalAccuracy, 10);
 LoggingCommand<SensorGps, String> gpsVerAccuracy(&gps, "vaccu", &SensorGps::getVerticalAccuracy, 10);
 
-LoggingCommand<SensorThermo, int> thermoEng(&thermo1, "tmpeng", &SensorThermo::getProbeTemp, 5);
+LoggingCommand<SensorThermo, int> thermoHead(&thermo1, "tmphead", &SensorThermo::getProbeTemp, 5);
+LoggingCommand<SensorThermo, int> thermoCrank(&thermo1, "tmpcnk", &SensorThermo::getProbeTemp, 5);
 
 LoggingCommand<SensorEcu, int> ecuRpm(&ecu, "rpm", &SensorEcu::getRPM, 1);
 LoggingCommand<SensorEcu, String> ecuMap(&ecu, "map", &SensorEcu::getMap, 1);
 LoggingCommand<SensorEcu, int> ecuTps(&ecu, "tps", &SensorEcu::getTPS, 1);
-LoggingCommand<SensorEcu, int> ecuEct(&ecu, "ect", &SensorEcu::getECT, 5);
-LoggingCommand<SensorEcu, int> ecuIat(&ecu, "iat", &SensorEcu::getIAT, 5);
+LoggingCommand<SensorEcu, int> ecuEct(&ecu, "tmpblk", &SensorEcu::getECT, 5);
+LoggingCommand<SensorEcu, int> ecuIat(&ecu, "tmpia", &SensorEcu::getIAT, 5);
 LoggingCommand<SensorEcu, String> ecuO2s(&ecu, "o2s", &SensorEcu::getO2S, 1);
 LoggingCommand<SensorEcu, int> ecuSpark(&ecu, "spar", &SensorEcu::getSpark, 1);
 LoggingCommand<SensorEcu, String> ecuFuel(&ecu, "pw1", &SensorEcu::getFuelPW1, 1);
@@ -65,12 +66,13 @@ void CurrentVehicle::debugSensorData() {
     DEBUG_SERIAL("Vertical Accuracy: " + gps.getVerticalAccuracy() + "m - ");
     DEBUG_SERIAL_LN("Satellites in View: " + String(gps.getSatellitesInView()));
     // Thermo
-    DEBUG_SERIAL_LN("Engine Temp (Thermocouple): " + String(thermo1.getProbeTemp()) + "°C");
+    DEBUG_SERIAL_LN("Engine Head Temp: " + String(thermo1.getProbeTemp()) + "°C");
+    DEBUG_SERIAL_LN("Engine Crankcase Temp: " + String(thermo2.getProbeTemp()) + "°C");
     // Engine Computer
     DEBUG_SERIAL("ECU RPM: " + String(ecu.getRPM()) + " - ");
     DEBUG_SERIAL("ECU MAP: " + ecu.getMap() + "kPa - ");
     DEBUG_SERIAL("ECU TPS: " + String(ecu.getTPS()) + "% - ");
-    DEBUG_SERIAL("ECU Coolant Temp: " + String(ecu.getECT()) + "°C - ");
+    DEBUG_SERIAL("ECU Block Temp: " + String(ecu.getECT()) + "°C - ");
     DEBUG_SERIAL("ECU Intake Temp: " + String(ecu.getIAT()) + "°C - ");
     DEBUG_SERIAL("ECU O2 Sensor: " + ecu.getO2S() + "v - ");
     DEBUG_SERIAL("ECU Spark Advance: " + String(ecu.getSpark()) + "° - ");


### PR DESCRIPTION
Changes temp sensor properties to the following:

- Thermo1 will be placed on the Engine Head (tmphead)
- Thermo2 will be placed on the Engine Crankcase (tmpcnk)
- ECU ECT (Engine Coolant Temp) sensor is actually placed on Engine Block (tmpblk)
- ECU IAT (Intake Air Temperature) sensor will be used for Intake Air Temp, but short name changed to (tmpia)

Sensor doc on Google Drive has been updated